### PR TITLE
Douglas' Project: mongodb dataflights

### DIFF
--- a/challenges/desafio1.js
+++ b/challenges/desafio1.js
@@ -1,0 +1,1 @@
+db.voos.count();

--- a/challenges/desafio10.js
+++ b/challenges/desafio10.js
@@ -1,0 +1,13 @@
+// Retorne apenas os 10 primeiros documentos com voos da empresa GOL do ano de 2017. Exiba apenas os campos vooId, empresa.nome, aeroportoOrigem.nome, aeroportoDestino.nome, mes e ano.
+db.voos
+  .find(
+    { "empresa.nome": "AZUL", ano: 2017 },
+    {
+      "empresa.nome": 1,
+      "aeroportoOrigem.nome": 1,
+      "aeroportoDestino.nome": 1,
+      mes: 1,
+      ano: 1,
+    }
+  )
+  .limit(10);

--- a/challenges/desafio11.js
+++ b/challenges/desafio11.js
@@ -1,0 +1,2 @@
+// Retorne a quantidade de documentos em que o campo aeroportoDestino.pais não seja igual a ESTADOS UNIDOS.
+db.voos.count({ "aeroporto.destino": { $ne: "ESTADOS UNIDOS" } });

--- a/challenges/desafio11.js
+++ b/challenges/desafio11.js
@@ -1,2 +1,2 @@
 // Retorne a quantidade de documentos em que o campo aeroportoDestino.pais não seja igual a ESTADOS UNIDOS.
-db.voos.count({ "aeroporto.destino": { $ne: "ESTADOS UNIDOS" } });
+db.voos.count({ "aeroportoDestino.pais": { $ne: "ESTADOS UNIDOS" } });

--- a/challenges/desafio12.js
+++ b/challenges/desafio12.js
@@ -1,0 +1,4 @@
+// Conte os documentos em que o campo aeroportoDestino.pais seja igual a BRASIL, ARGENTINA ou CHILE
+db.voos.count({
+  "aeroportoDestino.pais": { $in: ["BRASIL", "ARGENTINA", "CHILE"] },
+});

--- a/challenges/desafio13.js
+++ b/challenges/desafio13.js
@@ -1,0 +1,4 @@
+// Conte os documentos em que o campo aeroportoDestino.continente não seja igual a EUROPA, ÁSIA e OCEANIA
+db.voos.count({
+  "aeroportoDestino.continente": { $nin: ["EUROPA", "ÁSIA", "OCEANIA"] },
+});

--- a/challenges/desafio2.js
+++ b/challenges/desafio2.js
@@ -1,0 +1,1 @@
+db.voos.find({ "empresa.nome": "AZUL" }).limit(10).pretty();

--- a/challenges/desafio3.js
+++ b/challenges/desafio3.js
@@ -1,0 +1,1 @@
+db.voos.count({ "empresa.nome": "AZUL" });

--- a/challenges/desafio4.js
+++ b/challenges/desafio4.js
@@ -1,0 +1,1 @@
+db.voos.count({ "empresa.nome": "GOL" });

--- a/challenges/desafio5.js
+++ b/challenges/desafio5.js
@@ -1,0 +1,2 @@
+// Retorne o vooId do décimo ao décimo segundo documento da coleção voos.
+db.voos.find({}, { vooID: 1 }).limit(3).skip(9).pretty();

--- a/challenges/desafio6.js
+++ b/challenges/desafio6.js
@@ -1,0 +1,5 @@
+// Retorne apenas os campos empresa.sigla, empresa.nome e passageiros do voo com o campo vooId igual a 756807
+db.voos.find(
+  { vooId: 756807 },
+  { "empresa.sigla": 1, "empresa.nome": 1, passageiros: 1 }
+);

--- a/challenges/desafio7.js
+++ b/challenges/desafio7.js
@@ -1,0 +1,2 @@
+// Retorne a quantidade de voos em que o ano seja menor do que 2017
+db.voos.count({ ano: { $lt: 2017 } });

--- a/challenges/desafio8.js
+++ b/challenges/desafio8.js
@@ -1,0 +1,2 @@
+// Retorne a quantidade de voos em que o ano seja maior do que 2016.
+db.voos.count({ ano: { $gt: 2016 } });

--- a/challenges/desafio9.js
+++ b/challenges/desafio9.js
@@ -1,0 +1,2 @@
+// Retorne a quantidade de voos dos anos de 2017 e 2018.
+db.voos.count({ $and: [{ ano: 2017 }, { ano: 2018 }] });


### PR DESCRIPTION
- [ ] Retorne a quantidade de documentos inseridos na coleção voos.
- [ ] Retorne os 10 primeiros documentos com voos da empresa AZUL.
- [ ] Retorne a quantidade de voos da empresa AZUL.
- [ ] Retorne a quantidade de voos da empresa GOL.
- [ ] Retorne o vooId do décimo ao décimo segundo documento da coleção voos.
- [ ] Retorne apenas os campos empresa.sigla, empresa.nome e passageiros do voo com o campo vooId igual a 756807.
- [ ] Retorne a quantidade de voos em que o ano seja menor do que 2017.
- [ ] Retorne a quantidade de voos em que o ano seja maior do que 2016.
- [ ] Retorne a quantidade de voos dos anos de 2017 e 2018.
- [ ] Retorne apenas os 10 primeiros documentos com voos da empresa GOL do ano de 2017. Exiba apenas os campos vooId, empresa.nome, aeroportoOrigem.nome, aeroportoDestino.nome, mes e ano.
- [ ] Retorne a quantidade de documentos em que o campo aeroportoDestino.pais não seja igual a ESTADOS UNIDOS.
- [ ] Conte os documentos em que o campo aeroportoDestino.pais seja igual a BRASIL, ARGENTINA ou CHILE.
- [ ] Conte os documentos em que o campo aeroportoDestino.continente não seja igual a EUROPA, ÁSIA e OCEANIA.
- [ ] Retorne o total de voos em que o país de origem não seja BRASIL.
- [ ] Retorne o total de voos com mais de 20 decolagens.
- [ ] Retorne o total de voos em que o campo natureza possui o valor Internacional.
- [ ] Retorne o total de voos em que o campo natureza possui o valor Doméstica.
- [ ] Retorne o vooId, mes e ano do primeiro voo com mais de 7000 passageiros pagos.
- [ ] Retorne o vooId do primeiro voo em que o campo litrosCombustivel exista.
- [ ] Retorne o vooId do primeiro voo em que o campo rtk não exista.
- [ ] Retorne o vooId do primeiro voo em que o campo litrosCombustivel seja maior ou igual a 1000.
- [ ] Retorne o vooId do primeiro voo em que a empresa seja DELTA AIRLINES ou AMERICAN AIRLINES, a sigla do aeroporto de origem seja SBGR e a sigla do aeroporto de destino seja KJFK.
- [ ] Retorne o vooId e litrosCombustivel do primeiro voo em que o campo litrosCombustivel não seja maior do que 1000 e o campo litrosCombustivel exista.
- [ ] Retorne o vooId, empresa.nome e litrosCombustivel do primeiro voo em que litrosCombustivel não seja maior do que 600 e a empresa não seja GOL ou AZUL, e o campo litrosCombustivel exista.
- [ ] Remova todos os voos da empresa AZUL em que a quantidade de combustível seja menor do que 400. Informe a quantidade de documentos removidos.
- [ ] Remova todos os voos da empresa GOL em que a quantidade de passageiros pagos esteja entre 5 e 10, incluindo os casos em que a quantidade é 5 e 10. Informe a quantidade de documentos removidos.
- [ ] Retorne a quantidade total de voos de natureza Doméstica que a empresa PASSAREDO possui, via uso de uma nova coleção chamada resumoVoos.
- [ ] Retorne a quantidade total de voos de natureza Doméstica que a empresa LATAM AIRLINES BRASIL possui, via uso de uma nova coleção chamada resumoVoos.